### PR TITLE
Updated nunjucks-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "castor-load-xmlcorpus": "^1.0.2",
     "heartbeats": "^1.1.1",
     "marked": "^0.3.2",
-    "nunjucks-markdown": "^0.5.2",
+    "nunjucks-markdown": "^0.7.0",
     "flat": "^1.3.0",
     "castor-render": "^1.0.0"
   },


### PR DESCRIPTION
I updated nunjucks-markdown today and it works much, much better. You can now include other nunjucks tags in the markdown tags and import markdown files directly by using ```{% markdown "content.md" %}```. Checkout the readme for full details.